### PR TITLE
Fix #12: Public key export doesn't work

### DIFF
--- a/src/main/java/com/wultra/security/ssl/pinning/Application.java
+++ b/src/main/java/com/wultra/security/ssl/pinning/Application.java
@@ -308,7 +308,7 @@ public class Application {
         try (FileReader fileReader = new FileReader(privateKeyPath)) {
             final PEMParser pemParser = new PEMParser(new BufferedReader(fileReader));
             // Expected key type is EC
-            final KeyFactory kf = KeyFactory.getInstance("EC");
+            final KeyFactory kf = KeyFactory.getInstance("ECDSA", "BC");
             final Object pemInfo = pemParser.readObject();
             pemParser.close();
             if (pemInfo instanceof PrivateKeyInfo) {


### PR DESCRIPTION
The problem was caused by not specifying "BC" as provider, @hvge had BC configured after Sun EC, hence the ClassCastException.