### PR TITLE
Fix #50: Update powerauth-crypto to 1.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
 
     <properties>
         <bcprov-jdk18on.version>1.76</bcprov-jdk18on.version>
+        <powerauth-crypto.version>1.5.1</powerauth-crypto.version>
     </properties>
 
     <dependencies>
@@ -73,7 +74,7 @@
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-java-crypto</artifactId>
-            <version>1.5.1</version>
+            <version>${powerauth-crypto.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>


### PR DESCRIPTION
Preparation, version 1.5.1 not yet released.